### PR TITLE
Bugfix: Replacing edge definition always throws an ArangoException

### DIFF
--- a/Core.Arango/Modules/Internal/ArangoGraphModule.cs
+++ b/Core.Arango/Modules/Internal/ArangoGraphModule.cs
@@ -88,7 +88,7 @@ namespace Core.Arango.Modules.Internal
 
             await SendAsync<ArangoVoid>(database, HttpMethod.Put,
                 ApiPath(database, $"gharial/{UrlEncode(graph)}/edge/{UrlEncode(edgeDefinition.Collection)}", parameter),
-                cancellationToken: cancellationToken);
+                edgeDefinition, cancellationToken: cancellationToken);
         }
 
         public async Task RemoveEdgeDefinitionAsync(ArangoHandle database, string graph, string edgeDefinition,


### PR DESCRIPTION
Replacing edge definition in graph always throws an ArangoException stating the edge defitnition is malformed because no edge definition was set in the body of the request. 

I've modified the code to include the EdgeDefinition object in the body of the request. 

I also added extra test to make sure the change was correct.