### PR TITLE
Linq methods

### DIFF
--- a/Core.Arango.Tests/Core.Arango.Tests.csproj
+++ b/Core.Arango.Tests/Core.Arango.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="LinqTest_DateTime.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.Priority" Version="1.1.6" />

--- a/Core.Arango.Tests/LinqTest.cs
+++ b/Core.Arango.Tests/LinqTest.cs
@@ -10,6 +10,7 @@ using Core.Arango.Tests.Core;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
+using System.Linq.Expressions;
 
 namespace Core.Arango.Tests
 {

--- a/Core.Arango.Tests/LinqTest.cs
+++ b/Core.Arango.Tests/LinqTest.cs
@@ -219,16 +219,6 @@ namespace Core.Arango.Tests
                     ClientKey = "CB"
                 }
             });
-
-        }
-
-        [Fact]
-        public async Task StringContains()
-        {
-            var q = Arango.Query<Project>("test").Where(x => x.Name.Contains("abc"));
-            _output.WriteLine(q.ToAql().aql);
-            _output.WriteLine("");
-            //_output.WriteLine(JsonConvert.SerializeObject(await q.ToListAsync(), Formatting.Indented));
         }
     }
 }

--- a/Core.Arango.Tests/LinqTest_BasicOperations.cs
+++ b/Core.Arango.Tests/LinqTest_BasicOperations.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Core.Arango.Protocol;
+using Core.Arango.Linq;
+using Core.Arango.Tests.Core;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Core.Arango.Tests
+{
+    public class LinqTest_BasicOperations : TestBase
+    {
+        private const string D = "test";
+        private readonly ITestOutputHelper _output;
+        public LinqTest_BasicOperations(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Any()
+        {
+            var q = Arango.Query<Activity>("test").Any();
+
+            Assert.True(q);
+        }
+
+        [Fact]
+        public async Task GroupBy()
+        {
+            var q = Arango.Query<Activity>("test")
+            .GroupBy(x => new
+            {
+                x.Start.Year,
+                x.Start.Month,
+                x.Start.Day
+            })
+            .Select(g => new
+            {
+                Day = g.Min(x => x.Revenue) //The error is here. The query on the database generates an array with a single item
+                                            //and its trying to parse it as a decimal.
+            });
+
+            var result = await q.ToListAsync();
+
+            _output.WriteLine(q.ToAql().aql);
+        }
+
+        [Fact]
+        public void Count()
+        {
+            var count = Arango.Query<Activity>("test")
+                .Count();
+            var longCount = Arango.Query<Activity>("test")
+                .LongCount();
+
+            Assert.Equal(5, count);
+            Assert.Equal(5L, longCount);
+        }
+
+        public override async Task InitializeAsync()
+        {
+            Arango = new ArangoContext(UniqueTestRealm());
+            await Arango.Database.CreateAsync(D);
+            await Arango.Collection.CreateAsync(D, nameof(Activity), ArangoCollectionType.Document);
+
+            await Arango.Document.CreateManyAsync(D, nameof(Activity), new List<Activity>
+            {
+                new()
+                {
+                    Key = "AA",
+                    Start = new DateTime(2021, 1, 30),
+                    End = new DateTime(2022, 2, 10),
+                    Revenue = 3.4m
+                },
+                new()
+                {
+                    Key = "AB",
+                    Start = new DateTime(2022, 5, 15),
+                    End = new DateTime(2050, 10, 3),
+                    Revenue = 4.4m
+                },
+                new()
+                {
+                    Key = "AC",
+                    Start = new DateTime(2022, 5, 15),
+                    End = new DateTime(2050, 10, 3),
+                    Revenue = 4.4m
+                },
+                new()
+                {
+                    Key = "AD",
+                    Start = new DateTime(2022, 5, 15),
+                    End = new DateTime(2050, 10, 3),
+                    Revenue = 4.4m
+                },
+                new()
+                {
+                    Key = "AE",
+                    Start = new DateTime(2026, 3, 15),
+                    End = new DateTime(2058, 2, 3),
+                    Revenue = 4.4m
+                }
+            });
+        }
+    }
+}

--- a/Core.Arango.Tests/LinqTest_BasicOperations.cs
+++ b/Core.Arango.Tests/LinqTest_BasicOperations.cs
@@ -13,6 +13,33 @@ using Xunit.Abstractions;
 
 namespace Core.Arango.Tests
 {
+    class Person
+    {
+        public string Name { get; set; }
+    }
+
+    class Pet
+    {
+        public string Name { get; set; }
+        public Person Owner { get; set; }
+    }
+
+    class OutterChain
+    {
+        public string Name { get; set; }
+        public List<InnerChain> innerChains { get; set; }
+    }
+
+    class InnerChain
+    {
+        public string A { get; set; }
+        public string B { get; set; }
+        public string C { get; set; }
+        public string D { get; set; }
+        public string E { get; set; }
+        public string F { get; set; }
+    }
+
     public class LinqTest_BasicOperations : TestBase
     {
         private const string D = "test";
@@ -52,6 +79,89 @@ namespace Core.Arango.Tests
         }
 
         [Fact]
+        public async Task GroupJoin()
+        {
+            Person magnus = new Person { Name = "Hedlund, Magnus" };
+            Person terry = new Person { Name = "Adams, Terry" };
+            Person charlotte = new Person { Name = "Weiss, Charlotte" };
+
+            Pet barley = new Pet { Name = "Barley", Owner = terry };
+            Pet boots = new Pet { Name = "Boots", Owner = terry };
+            Pet whiskers = new Pet { Name = "Whiskers", Owner = charlotte };
+            Pet daisy = new Pet { Name = "Daisy", Owner = magnus };
+
+            List<Person> people = new List<Person> { magnus, terry, charlotte };
+            List<Pet> pets = new List<Pet> { barley, boots, whiskers, daisy };
+
+            await Arango.Collection.CreateAsync(D, nameof(Person), ArangoCollectionType.Document);
+            await Arango.Collection.CreateAsync(D, nameof(Pet), ArangoCollectionType.Document);
+
+            await Arango.Document.CreateManyAsync(D, nameof(Person), people);
+            await Arango.Document.CreateManyAsync(D, nameof(Pet), pets);
+
+            var q = Arango.Query<Person>("test")
+                .GroupJoin(pets,
+                           person => person,
+                           pet => pet.Owner,
+                           (person, Pet) => //petColletion should be a parameter (@P1). So this will throw an error unless this collection is in the db
+                               new          //and it has the same name as said collection. Unless this is intended to work this way.
+                               {
+                                   OwnerName = person.Name,
+                                   pets = Pet.Select(pet => pet.Name)
+                               });
+
+            var result = await q.ToListAsync();
+
+            Assert.Single(result[0].pets);
+            Assert.Equal(2, result[1].pets.Count());
+            Assert.Single(result[3].pets);
+
+            _output.WriteLine(q.ToAql().aql);
+        }
+
+        //Check the AQL being generated
+        [Fact]
+        public async Task Join()
+        {
+            Person magnus = new Person { Name = "Hedlund, Magnus" };
+            Person terry = new Person { Name = "Adams, Terry" };
+            Person charlotte = new Person { Name = "Weiss, Charlotte" };
+
+            Pet barley = new Pet { Name = "Barley", Owner = terry };
+            Pet boots = new Pet { Name = "Boots", Owner = terry };
+            Pet whiskers = new Pet { Name = "Whiskers", Owner = charlotte };
+            Pet daisy = new Pet { Name = "Daisy", Owner = magnus };
+
+            List<Person> people = new List<Person> { magnus, terry, charlotte };
+            List<Pet> pets = new List<Pet> { barley, boots, whiskers, daisy };
+
+            await Arango.Collection.CreateAsync(D, nameof(Person), ArangoCollectionType.Document);
+            await Arango.Collection.CreateAsync(D, nameof(Pet), ArangoCollectionType.Document);
+
+            await Arango.Document.CreateManyAsync(D, nameof(Person), people);
+            await Arango.Document.CreateManyAsync(D, nameof(Pet), pets);
+
+            var q = Arango.Query<Person>("test")
+                .Join(pets,
+                           person => person,
+                           pet => pet.Owner,
+                           (person, Pet) => //petColletion should be a parameter (@P1). So this will throw an error unless this collection is in the db
+                               new          //and it has the same name as said collection. Unless this is intended to work this way.
+                               {
+                                   OwnerName = person.Name,
+                                   Pet = Pet.Name
+                               });
+
+            var result = await q.ToListAsync();
+
+            Assert.Equal("Barley", result[0].Pet);
+            Assert.Equal("Boots", result[1].Pet);
+            Assert.Equal("Whiskers", result[2].Pet);
+            Assert.Equal("Daisy", result[3].Pet);
+
+            _output.WriteLine(q.ToAql().aql);
+        }
+
         public void Count()
         {
             var count = Arango.Query<Activity>("test")
@@ -61,6 +171,170 @@ namespace Core.Arango.Tests
 
             Assert.Equal(5, count);
             Assert.Equal(5L, longCount);
+        }
+
+        [Fact]
+        public void All()
+        {
+            var boolean = Arango.Query<Activity>("test").All(x => x.Key.Contains("A"));
+
+            Assert.True(boolean);
+        }
+
+        [Fact]
+        public async Task Contains()
+        {
+            var p = await Arango.Query<Activity>("test").FirstOrDefaultAsync();
+
+            var boolean = Arango.Query<Activity>("test").Contains(p);
+
+            Assert.True(boolean);
+        }
+
+        [Fact]
+        public async Task Distinct()
+        {
+            Person per1 = new Person { Name = "Person1" };
+            Person per2 = new Person { Name = "Person1" };
+            Person per3 = new Person { Name = "Person2" };
+
+            List<Person> people = new List<Person> { per1, per2, per3 };
+
+            await Arango.Collection.CreateAsync(D, nameof(Person), ArangoCollectionType.Document);
+            await Arango.Document.CreateManyAsync(D, nameof(Person), people);
+            
+            var p = await Arango.Query<Person>("test").Distinct().ToListAsync();
+
+            Assert.Equal(2, p.Count());
+        }
+
+        [Fact]
+        public async Task Except()
+        {
+            var list = await Arango.Query<Activity>("test").Take(2).ToListAsync();
+
+            var p = await Arango.Query<Activity>("test").Except(list).ToListAsync();
+
+            Assert.Equal(2, p.Count());
+        }
+
+        [Fact]
+        public async Task Intersect()
+        {
+            var list = await Arango.Query<Activity>("test").Take(1).ToListAsync();
+
+            var p = await Arango.Query<Activity>("test").Intersect(list).ToListAsync();
+
+            Assert.Single(p);
+        }
+
+        [Fact]
+        public async Task Union()
+        {
+            var personList1 = new List<Person>
+            {
+                new Person { Name = "Person1" },
+                new Person { Name = "Person2" },
+                new Person { Name = "Person3" },
+                new Person { Name = "Person4" }
+            };
+            var personList2 = new List<Person>
+            {
+                new Person { Name = "Person3" },
+                new Person { Name = "Person4" },
+                new Person { Name = "Person5" },
+                new Person { Name = "Person6" }
+            };
+
+            await Arango.Collection.CreateAsync(D, nameof(Person), ArangoCollectionType.Document);
+
+            await Arango.Document.CreateManyAsync(D, nameof(Person), personList1);
+
+            var p = await Arango.Query<Person>("test").Union(personList2).ToListAsync();
+
+            Assert.Equal(6, p.Count());
+        }
+
+        //This test has precision issues.
+        [Fact]
+        public async Task Average()
+        {
+            var expectedAverage = (new List<decimal> { 3.4m, 4.4m }).AsQueryable().Average();
+            var average = Arango.Query<Activity>("test").Where(x => x.Key == "AA" || x.Key == "AB").Select(x => x.Revenue).Average();
+
+            Assert.Equal(expectedAverage, average);
+        }
+
+        [Fact]
+        public async Task Min()
+        {
+            var min = Arango.Query<Activity>("test").Select(x => x.Revenue).Min();
+
+            Assert.Equal(3.4m, min);
+        }
+
+        [Fact]
+        public async Task Max()
+        {
+            var max = Arango.Query<Activity>("test").Select(x => x.Revenue).Max();
+
+            Assert.Equal(4.4m, max);
+        }
+
+        [Fact]
+        public async Task Sum()
+        {
+            var expectedSum = (4.4m * 4) + 3.4m;
+            var sum = Arango.Query<Activity>("test").Select(x => x.Revenue).Sum();
+
+            Assert.Equal(expectedSum, sum);
+        }
+
+        [Fact]
+        public async Task SameVariableChained()
+        {
+            var chainTest = new OutterChain()
+            {
+                Name = "OutterChain_1",
+                innerChains = new List<InnerChain>()
+                {
+                    new InnerChain()
+                    {
+                        A = "A",
+                        B = "B",
+                        C = "C",
+                        D = "D",
+                        E = "E",
+                        F = "F"
+                    },
+                    new InnerChain()
+                    {
+                        A = "A",
+                        B = "B",
+                        C = "C",
+                        D = "D",
+                        E = "E",
+                        F = "F"
+                    },
+                    new InnerChain()
+                    {
+                        A = "A",
+                        B = "B",
+                        C = "C",
+                        D = "D",
+                        E = "E",
+                        F = "F"
+                    }
+                }
+            };
+
+            await Arango.Collection.CreateAsync("test", nameof(OutterChain), ArangoCollectionType.Document);
+            await Arango.Document.CreateAsync("test", nameof(OutterChain), chainTest);
+
+            var q = Arango.Query<OutterChain>("test").SelectMany(x => x.innerChains).Where(x => x.A == "A").Where(x => x.B == "B").Where(x => x.C == "C").Where(x => x.D == "D").Where(x => x.E == "E").Where(x => x.F == "F");
+            var c = await q.FirstOrDefaultAsync();
+
+            _output.WriteLine(q.ToAql().aql);
         }
 
         public override async Task InitializeAsync()

--- a/Core.Arango.Tests/LinqTest_DateTime.cs
+++ b/Core.Arango.Tests/LinqTest_DateTime.cs
@@ -38,14 +38,15 @@ namespace Core.Arango.Tests
         public async Task Add()
         {
             var time = new DateTime(2021, 1, 30);
-            time = time.ToUniversalTime();
             var time2 = time.AddYears(1);
-            var q = Arango.Query<Activity>("test").Where(x => x.Start.AddYears(1) == time2);
-            var q2 = Arango.Query<Activity>("test").Where(x => x.Start == time);
+            //time = time.ToUniversalTime();
+            //var time2 = time.AddYears(1);
+            //var q = Arango.Query<Activity>("test").Where(x => x.Start.AddYears(1) == time2);
+            var q2 = Arango.Query<Activity>("test").Where(x => x.Start.AddYears(1) == time2);
 
             var a = await q2.FirstOrDefaultAsync();
             Assert.Equal("AA", a.Key);
-            _output.WriteLine(q.ToAql().aql);
+            //_output.WriteLine(q.ToAql().aql);
             _output.WriteLine(q2.ToAql().aql);
         }
 
@@ -66,8 +67,8 @@ namespace Core.Arango.Tests
                 new()
                 {
                     Key = "AB",
-                    Start = new DateTime(2000, 5, 15),
-                    End = new DateTime(2010, 10, 3)
+                    Start = new DateTime(2022, 5, 15),
+                    End = new DateTime(2050, 10, 3)
                 }
             });
         }

--- a/Core.Arango.Tests/LinqTest_DateTime.cs
+++ b/Core.Arango.Tests/LinqTest_DateTime.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Core.Arango.Protocol;
+using Core.Arango.Linq;
+using Core.Arango.Tests.Core;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Core.Arango.Tests
+{
+    public class LinqTest_DateTime : TestBase
+    {
+        private const string D = "test";
+        private readonly ITestOutputHelper _output;
+        public LinqTest_DateTime(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task GetDateProperty()
+        {
+            //The same as the Lenght property on the string tests, we need a way to transform properties from objects to methods in AQL.
+            var time = new DateTime(2021, 1, 30);
+            //var q = Arango.Query<Activity>("test").Where(x => x.Start.Month < time.Month); //This is how the end user should write the LINQ method
+            var q = Arango.Query<Activity>("test").Where(x => Aql.DateMonth(x.Start) < time.Month);
+            var a = await q.FirstOrDefaultAsync();
+            Assert.Null(a);
+            _output.WriteLine(q.ToAql().aql);
+        }
+
+        [Fact]
+        public async Task Add()
+        {
+            var time = new DateTime(2021, 1, 30);
+            time = time.ToUniversalTime();
+            var time2 = time.AddYears(1);
+            var q = Arango.Query<Activity>("test").Where(x => x.Start.AddYears(1) == time2);
+            var q2 = Arango.Query<Activity>("test").Where(x => x.Start == time);
+
+            var a = await q2.FirstOrDefaultAsync();
+            Assert.Equal("AA", a.Key);
+            _output.WriteLine(q.ToAql().aql);
+            _output.WriteLine(q2.ToAql().aql);
+        }
+
+        public override async Task InitializeAsync()
+        {
+            Arango = new ArangoContext(UniqueTestRealm());
+            await Arango.Database.CreateAsync(D);
+            await Arango.Collection.CreateAsync(D, nameof(Activity), ArangoCollectionType.Document);
+
+            await Arango.Document.CreateManyAsync(D, nameof(Activity), new List<Activity>
+            {
+                new()
+                {
+                    Key = "AA",
+                    Start = new DateTime(2021, 1, 30),
+                    End = new DateTime(2022, 2, 10)
+                },
+                new()
+                {
+                    Key = "AB",
+                    Start = new DateTime(2000, 5, 15),
+                    End = new DateTime(2010, 10, 3)
+                }
+            });
+        }
+    }
+}

--- a/Core.Arango.Tests/LinqTest_String.cs
+++ b/Core.Arango.Tests/LinqTest_String.cs
@@ -25,11 +25,13 @@ namespace Core.Arango.Tests
         [Fact]
         public async Task StringConcat()
         {
-            var project1 = "Project";
-            var project2 = " A";
+            var project1 = "Project A";
+            var project2 = "PA";
 
-            var p = await Arango.Query<Project>("test").Where(x => x.Name == String.Concat(project1, project2)).FirstOrDefaultAsync();
+            var p = await Arango.Query<Project>("test").Where(x => x.Name.Concat(x.Key) == String.Concat(project1, project2)).FirstOrDefaultAsync();
+            var q = Arango.Query<Project>("test").Where(x => x.Name == String.Concat(project1, project2));
             Assert.Equal("Project A", p.Name);
+            _output.WriteLine(q.ToAql().aql);
         }
 
         [Fact]
@@ -91,11 +93,12 @@ namespace Core.Arango.Tests
             var p = await Arango.Query<Project>("test").Where(x => x.Name.Length == "Project A".Length).FirstOrDefaultAsync();
             //var q = Arango.Query<Project>("test").Where(x => x.Name.Length == "Project A".Length); //Doesn't work at the moment
             var q = Arango.Query<Project>("test").Where(x => x.Name.Count() == "Project A".Count()); //Doesn't work at the moment
-            //Assert.Equal("Project A", p.Name);
-            _output.WriteLine(q.ToAql().aql);
+            Assert.Equal("Project A", p.Name);
+            //_output.WriteLine(q.ToAql().aql);
             //_output.WriteLine((await q.FirstOrDefaultAsync()).Name);
         }
 
+        [Fact]
         //TODO: Here we would use the CONTAINS() AQL method using the optional bool parameter. Need to check how to do that.
         public async Task StringIndexOf()
         {
@@ -104,6 +107,60 @@ namespace Core.Arango.Tests
             //Assert.Equal("Project A", p.Name);
             //_output.WriteLine(q.ToAql().aql);
         }
+
+        [Fact]
+        public async Task StringSplit()
+        {
+            //var p = await Arango.Query<Project>("test").Where(x => x.Name.Split(' ').First() == "A").FirstOrDefaultAsync(); //TODO: Check how to handle optional parameters
+            //Assert.Equal("Project A", p.Name);
+            //_output.WriteLine(q.ToAql().aql);
+        }
+
+        [Fact]
+        public async Task StringReplace()
+        {
+            var p = await Arango.Query<Project>("test").Where(x => x.Name.Replace('A', 'C') == "Project C").FirstOrDefaultAsync();
+            Assert.Equal("Project A", p.Name);
+        }
+
+        [Fact]
+        public async Task StringSubstring()
+        {
+            var p1 = await Arango.Query<Project>("test").Where(x => x.Name.Substring(8) == "A").FirstOrDefaultAsync();
+            var p2 = await Arango.Query<Project>("test").Where(x => x.Name.Substring(1, 8) == "roject A").FirstOrDefaultAsync();
+            Assert.Equal("Project A", p1.Name);
+            Assert.Equal("Project A", p2.Name);
+        }
+
+        [Fact]
+        public async Task StringToLower()
+        {
+            var p = await Arango.Query<Project>("test").Where(x => x.Name.ToLower() == "project a").FirstOrDefaultAsync();
+            Assert.Equal("Project A", p.Name);
+        }
+
+        [Fact]
+        public async Task StringToUpper()
+        {
+            var p = await Arango.Query<Project>("test").Where(x => x.Name.ToUpper() == "PROJECT A").FirstOrDefaultAsync();
+            Assert.Equal("Project A", p.Name);
+        }
+
+        [Fact]
+        public async Task Temp()
+        {
+            var keys = new List<string>
+            {
+                "PA",
+                "PC"
+            };
+
+            var arrKeys = keys.ToArray();
+
+            var p = await Arango.Query<Project>("test").Where(x => Aql.Position(arrKeys, x.Key)).ToListAsync();
+
+        }
+
 
         public override async Task InitializeAsync()
         {

--- a/Core.Arango.Tests/LinqTest_String.cs
+++ b/Core.Arango.Tests/LinqTest_String.cs
@@ -108,10 +108,11 @@ namespace Core.Arango.Tests
             //_output.WriteLine(q.ToAql().aql);
         }
 
+        //TODO: Check how to handle optional parameters
         [Fact]
         public async Task StringSplit()
         {
-            //var p = await Arango.Query<Project>("test").Where(x => x.Name.Split(' ').First() == "A").FirstOrDefaultAsync(); //TODO: Check how to handle optional parameters
+            //var p = await Arango.Query<Project>("test").Where(x => x.Name.Split(' ').First() == "A").FirstOrDefaultAsync(); 
             //Assert.Equal("Project A", p.Name);
             //_output.WriteLine(q.ToAql().aql);
         }
@@ -149,25 +150,36 @@ namespace Core.Arango.Tests
         [Fact]
         public async Task Temp()
         {
-            //var keys = new List<string>
-            //{
-            //    "PA",
-            //    "PC"
-            //};
+            String[] keys = { "PA", "PB" };
 
-            //var arrKeys = keys.ToArray();
+            var arrKeys = keys.ToArray();
 
-            //var p = await Arango.Query<Project>("test").Where(x => keys.Contains()).ToListAsync();
-            var p = Arango.Query<Project>("test").Where(x => x.Name.Equals("Project A"));
-            var q = p.ToAql();
+            //var p = Arango.Query<Project>("test");
+            //var q = p.Where(x => Aql.Position(keys, x.Name));
+            //var q = p.Where(x => keys.Contains(x.Key));
+            //var qq = q.ToAql().aql;
 
-            var p2 = Arango.Query<Project>("test").Where(x => x.Name == "abc");
-            var q2 = p2.ToAql();
+            //var p1 = Arango.Query<Project>("test");
+            //var q1 = p1.Where(x => x.Name.ToUpper() == "Project A");
+            //var qq1 = q1.ToAql().aql;
 
-            var a = await p.FirstOrDefaultAsync();
-            _output.WriteLine(a.Name);
-            _output.WriteLine(q.aql);
-            _output.WriteLine(q2.aql);  
+            //var p = Arango.Query<Project>("test").Where(x => x.Name.Equals("Project A"));
+            //var q = p.ToAql();
+
+            //var p2 = Arango.Query<Project>("test").Where(x => x.Name == "abc");
+            //var q2 = p2.ToAql();
+
+            //var a = await p.FirstOrDefaultAsync();
+            //_output.WriteLine(a.Name);
+            //_output.WriteLine(q.aql);
+            //_output.WriteLine(q2.aql);
+
+            //Math functions seem to be working
+            var q = Arango.Query<Project>("test")
+                //.Where(x => Math.Floor(x.Budget) == 10)
+                .Where(x => Math.Abs(x.Budget) == 10)
+                ;
+            _output.WriteLine(q.ToAql().aql);
 
         }
 
@@ -200,13 +212,15 @@ namespace Core.Arango.Tests
                 {
                     Key = "PA",
                     Name = "Project A",
-                    ClientKey = "CA"
+                    ClientKey = "CA",
+                    Budget = 10.1
                 },
                 new ()
                 {
                     Key = "PB",
                     Name = "Project B",
-                    ClientKey = "CB"
+                    ClientKey = "CB",
+                    Budget = 11.2
                 }
             });
         }

--- a/Core.Arango.Tests/LinqTest_String.cs
+++ b/Core.Arango.Tests/LinqTest_String.cs
@@ -25,11 +25,11 @@ namespace Core.Arango.Tests
         [Fact]
         public async Task StringConcat()
         {
-            var project1 = "Project A";
-            var project2 = "PA";
+            var project1 = "Project";
+            var project2 = " A";
 
-            var p = await Arango.Query<Project>("test").Where(x => x.Name.Concat(x.Key) == String.Concat(project1, project2)).FirstOrDefaultAsync();
-            var q = Arango.Query<Project>("test").Where(x => x.Name == String.Concat(project1, project2));
+            var p = await Arango.Query<Project>("test").Where(x => x.Name == string.Concat(project1, project2)).FirstOrDefaultAsync();
+            var q = Arango.Query<Project>("test").Where(x => x.Name.Concat(" 10") == "Project A 10");
             Assert.Equal("Project A", p.Name);
             _output.WriteLine(q.ToAql().aql);
         }
@@ -149,15 +149,25 @@ namespace Core.Arango.Tests
         [Fact]
         public async Task Temp()
         {
-            var keys = new List<string>
-            {
-                "PA",
-                "PC"
-            };
+            //var keys = new List<string>
+            //{
+            //    "PA",
+            //    "PC"
+            //};
 
-            var arrKeys = keys.ToArray();
+            //var arrKeys = keys.ToArray();
 
-            var p = await Arango.Query<Project>("test").Where(x => Aql.Position(arrKeys, x.Key)).ToListAsync();
+            //var p = await Arango.Query<Project>("test").Where(x => keys.Contains()).ToListAsync();
+            var p = Arango.Query<Project>("test").Where(x => x.Name.Equals("Project A"));
+            var q = p.ToAql();
+
+            var p2 = Arango.Query<Project>("test").Where(x => x.Name == "abc");
+            var q2 = p2.ToAql();
+
+            var a = await p.FirstOrDefaultAsync();
+            _output.WriteLine(a.Name);
+            _output.WriteLine(q.aql);
+            _output.WriteLine(q2.aql);  
 
         }
 

--- a/Core.Arango.Tests/LinqTest_String.cs
+++ b/Core.Arango.Tests/LinqTest_String.cs
@@ -22,15 +22,14 @@ namespace Core.Arango.Tests
             _output = output;
         }
 
-        //Concat doesn't seems to be picked up by the ArangoExpressionTreeVisitor. Comment the Assert line and check the AQL generated.
         [Fact]
         public async Task StringConcat()
         {
-            var q = Arango.Query<Project>("test").Where(x => (string)x.Name.Concat(" 10") == "Project A 10");
+            var q = Arango.Query<Project>("test").Where(x => String.Concat(x.Name, " 10") == "Project A 10");
             var p = await q.FirstOrDefaultAsync();
             
             Assert.Equal("Project A", p.Name);
-            _output.WriteLine(q.ToAql().aql);
+            //_output.WriteLine(q.ToAql().aql);
         }
 
         [Fact]
@@ -148,7 +147,6 @@ namespace Core.Arango.Tests
             //_output.WriteLine(q2.ToAql().aql);
         }
 
-        //TODO: Handle cases when properties can be translated as functions in AQL
         [Fact]
         public async Task StringLen()
         {
@@ -169,7 +167,6 @@ namespace Core.Arango.Tests
             //_output.WriteLine(q.ToAql().aql);
         }
 
-        //TODO: Check how to handle optional parameters
         [Fact]
         public async Task StringSplit()
         {

--- a/Core.Arango.Tests/LinqTest_String.cs
+++ b/Core.Arango.Tests/LinqTest_String.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Core.Arango.Protocol;
+using Core.Arango.Linq;
+using Core.Arango.Tests.Core;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Core.Arango.Tests
+{
+    public class LinqTest_String : TestBase
+    {
+        private const string D = "test";
+        private readonly ITestOutputHelper _output;
+        public LinqTest_String(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task StringConcat()
+        {
+            var project1 = "Project";
+            var project2 = " A";
+
+            var p = await Arango.Query<Project>("test").Where(x => x.Name == String.Concat(project1, project2)).FirstOrDefaultAsync();
+            Assert.Equal("Project A", p.Name);
+        }
+
+        [Fact]
+        public async Task StringContains()
+        {
+            var p = await Arango.Query<Project>("test").Where(x => x.Name.Contains("A")).FirstOrDefaultAsync();
+            Assert.Equal("Project A", p.Name);
+        }
+
+        [Fact]
+        public async Task StringTrim()
+        {
+            var project1 = " Project A ";
+            var project2 = "-||Project A||-";
+
+            char[] charsToDelete = { '|', '-' };
+
+            var p1 = await Arango.Query<Project>("test").Where(x => project1.Trim() == "Project A").FirstOrDefaultAsync();
+            var p2 = await Arango.Query<Project>("test").Where(x => project2.Trim(charsToDelete) == "Project A").FirstOrDefaultAsync();
+
+            Assert.Equal("Project A", p1.Name);
+            Assert.Equal("Project A", p2.Name);
+        }
+
+        [Fact]
+        public async Task StringTrimStart()
+        {
+            var project1 = " Project A";
+            var project2 = "-||Project A";
+
+            char[] charsToDelete = { '|', '-' };
+
+            var p1 = await Arango.Query<Project>("test").Where(x => project1.TrimStart() == "Project A").FirstOrDefaultAsync();
+            var p2 = await Arango.Query<Project>("test").Where(x => project2.TrimStart(charsToDelete) == "Project A").FirstOrDefaultAsync();
+
+            Assert.Equal("Project A", p1.Name);
+            Assert.Equal("Project A", p2.Name);
+        }
+
+        [Fact]
+        public async Task StringTrimEnd()
+        {
+            var project1 = "Project A ";
+            var project2 = "Project A||-";
+
+            char[] charsToDelete = { '|', '-' };
+
+            var p1 = await Arango.Query<Project>("test").Where(x => project1.TrimEnd() == "Project A").FirstOrDefaultAsync();
+            var p2 = await Arango.Query<Project>("test").Where(x => project2.TrimEnd(charsToDelete) == "Project A").FirstOrDefaultAsync();
+
+            Assert.Equal("Project A", p1.Name);
+            Assert.Equal("Project A", p2.Name);
+        }
+
+        //TODO: Handle cases when properties can be translated as functions in AQL
+        [Fact]
+        public async Task StringLen()
+        {
+            var p = await Arango.Query<Project>("test").Where(x => x.Name.Length == "Project A".Length).FirstOrDefaultAsync();
+            //var q = Arango.Query<Project>("test").Where(x => x.Name.Length == "Project A".Length); //Doesn't work at the moment
+            var q = Arango.Query<Project>("test").Where(x => x.Name.Count() == "Project A".Count()); //Doesn't work at the moment
+            //Assert.Equal("Project A", p.Name);
+            _output.WriteLine(q.ToAql().aql);
+            //_output.WriteLine((await q.FirstOrDefaultAsync()).Name);
+        }
+
+        //TODO: Here we would use the CONTAINS() AQL method using the optional bool parameter. Need to check how to do that.
+        public async Task StringIndexOf()
+        {
+            //var p = await Arango.Query<Project>("test").Where(x => x.Name.IndexOf("A") == "Project A".IndexOf("A")).FirstOrDefaultAsync();
+            //var q = Arango.Query<Project>("test").Where(x => x.Name.IndexOf("A") == "Project A".IndexOf("A"));
+            //Assert.Equal("Project A", p.Name);
+            //_output.WriteLine(q.ToAql().aql);
+        }
+
+        public override async Task InitializeAsync()
+        {
+            Arango = new ArangoContext(UniqueTestRealm());
+            await Arango.Database.CreateAsync(D);
+            await Arango.Collection.CreateAsync(D, nameof(Client), ArangoCollectionType.Document);
+            await Arango.Collection.CreateAsync(D, nameof(Project), ArangoCollectionType.Document);
+            await Arango.Collection.CreateAsync(D, nameof(Activity), ArangoCollectionType.Document);
+
+            await Arango.Document.CreateManyAsync(D, nameof(Client), new List<Client>
+            {
+                new()
+                {
+                    Key = "CA",
+                    Name = "Client A"
+                },
+                new()
+                {
+                    Key = "CB",
+                    Name = "Client B"
+                }
+            });
+
+            await Arango.Document.CreateManyAsync(D, nameof(Project), new List<Project>
+            {
+                new ()
+                {
+                    Key = "PA",
+                    Name = "Project A",
+                    ClientKey = "CA"
+                },
+                new ()
+                {
+                    Key = "PB",
+                    Name = "Project B",
+                    ClientKey = "CB"
+                }
+            });
+        }
+    }
+}

--- a/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
+++ b/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
@@ -61,8 +61,6 @@ namespace Core.Arango.Linq.Query
             else if (expression.Method.DeclaringType == typeof(string))
             {
                 // TODO: map methods
-                methodName = expression.Method.Name;
-
                 methodName = expression.Method.Name switch
                 {
                     "Contains" => "Contains",

--- a/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
+++ b/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
@@ -58,13 +58,36 @@ namespace Core.Arango.Linq.Query
                 else
                     throw new InvalidOperationException($"Method {expression.Method.Name} is not supported in ArangoLinqProvider");
             }
+            else if(expression.Method.Name == "Equals")
+            {
+                ModelVisitor.QueryText.Append(" ( ");
+
+                Visit(expression.Object);
+
+                string argumentSeprator1 = "== ";
+
+                if (expression.Arguments.Count >= 1)
+                    ModelVisitor.QueryText.Append(argumentSeprator1);
+
+                for (var i = 0; i < expression.Arguments.Count; i++)
+                {
+                    Visit(expression.Arguments[i]);
+
+                    if (i != expression.Arguments.Count - 1)
+                        ModelVisitor.QueryText.Append(argumentSeprator1);
+                }
+
+                ModelVisitor.QueryText.Append(" ) ");
+
+                return expression;
+            }
             else if (expression.Method.DeclaringType == typeof(string))
             {
                 // TODO: map methods
                 methodName = expression.Method.Name switch
                 {
                     "Contains" => "CONTAINS", //TODO: We can also use the contains method for the String.IndexOf()
-                    "Concat" => "concat",
+                    //"Concat" => "CONCAT",
                     "Trim" => "TRIM",
                     "TrimStart" => "LTRIM",
                     "TrimEnd" => "RTRIM",

--- a/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
+++ b/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
@@ -63,8 +63,14 @@ namespace Core.Arango.Linq.Query
                 // TODO: map methods
                 methodName = expression.Method.Name switch
                 {
-                    "Contains" => "Contains",
-                    "Concat" => "Concat",
+                    "Contains" => "CONTAINS",
+                    "Concat" => "CONCAT",
+                    "Trim" => "TRIM",
+                    "TrimStart" => "LTRIM",
+                    "TrimEnd" => "RTRIM",
+                    "Length" => "LENGTH",
+                    "Count" => "LENGTH",
+                    "Split" => "SPLIT",
                     "" => expression.Method.Name // TODO : this should probably throw like in the 'else' case (so first check on 'AqlFunctionAttribute'?)
                 };
 

--- a/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
+++ b/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
@@ -63,14 +63,29 @@ namespace Core.Arango.Linq.Query
                 // TODO: map methods
                 methodName = expression.Method.Name switch
                 {
-                    "Contains" => "CONTAINS",
-                    "Concat" => "CONCAT",
+                    "Contains" => "CONTAINS", //TODO: We can also use the contains method for the String.IndexOf()
+                    "Concat" => "concat",
                     "Trim" => "TRIM",
                     "TrimStart" => "LTRIM",
                     "TrimEnd" => "RTRIM",
                     "Length" => "LENGTH",
                     "Count" => "LENGTH",
                     "Split" => "SPLIT",
+                    "Replace" => "SUBSTITUTE",
+                    "Substring" => "SUBSTRING",
+                    "ToLower" => "LOWER",
+                    "ToUpper" => "UPPER",
+                    "" => expression.Method.Name // TODO : this should probably throw like in the 'else' case (so first check on 'AqlFunctionAttribute'?)
+                };
+
+                pushObjectAsArgument = true;
+            }
+            else if (typeof(IEnumerable).IsAssignableFrom(expression.Method.DeclaringType))
+            {
+                // TODO: map methods
+                methodName = expression.Method.Name switch
+                {
+                    "Contains" => "POSITION", //TODO: We can also use the contains method for the String.IndexOf()
                     "" => expression.Method.Name // TODO : this should probably throw like in the 'else' case (so first check on 'AqlFunctionAttribute'?)
                 };
 

--- a/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
+++ b/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
@@ -85,12 +85,13 @@ namespace Core.Arango.Linq.Query
             {
                 methodName = expression.Method.Name switch
                 {
-                    "Contains" => "CONTAINS", //TODO: We can also use the contains method for the String.IndexOf()
+                    "Contains" => "CONTAINS",
+                    "IndexOf" => "CONTAINS",
                     "Concat" => "CONCAT",
                     "Trim" => "TRIM",
                     "TrimStart" => "LTRIM",
                     "TrimEnd" => "RTRIM",
-                    "Length" => "LENGTH",
+                    "Length" => "LENGTH", //We need to check if an object property can be translated as a method.
                     "Count" => "LENGTH",
                     "Split" => "SPLIT",
                     "Replace" => "SUBSTITUTE",
@@ -190,6 +191,14 @@ namespace Core.Arango.Linq.Query
                     "AddMilliseconds" => " \"f\" ",
                     "" => expression.Method.Name
                 };
+
+                ModelVisitor.QueryText.Append(parameter);
+            }
+            else if (expression.Method.DeclaringType == typeof(string) && expression.Method.Name == "IndexOf")
+            {
+                ModelVisitor.QueryText.Append(argumentSeprator);
+
+                string parameter = " true ";
 
                 ModelVisitor.QueryText.Append(parameter);
             }

--- a/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
+++ b/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
@@ -62,6 +62,14 @@ namespace Core.Arango.Linq.Query
             {
                 // TODO: map methods
                 methodName = expression.Method.Name;
+
+                methodName = expression.Method.Name switch
+                {
+                    "Contains" => "Contains",
+                    "Concat" => "Concat",
+                    "" => expression.Method.Name // TODO : this should probably throw like in the 'else' case (so first check on 'AqlFunctionAttribute'?)
+                };
+
                 pushObjectAsArgument = true;
             }
             else

--- a/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
+++ b/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
@@ -103,27 +103,6 @@ namespace Core.Arango.Linq.Query
                 if(methodName != "CONCAT")
                     pushObjectAsArgument = true;
             }
-            else if (expression.Method.DeclaringType == typeof(DateTime))
-            {
-                methodName = expression.Method.Name switch
-                {
-                    "AddYears" => "DATE_ADD", //TODO: We can also use the contains method for the String.IndexOf()
-                    "" => expression.Method.Name // TODO : this should probably throw like in the 'else' case (so first check on 'AqlFunctionAttribute'?)
-                };
-
-                pushObjectAsArgument = true;
-            }
-            else if (expression.Method.DeclaringType.IsArray)
-            {
-                // TODO: map methods
-                methodName = expression.Method.Name switch
-                {
-                    "Contains" => "POSITION", //TODO: We can also use the contains method for the String.IndexOf()
-                    "" => expression.Method.Name // TODO : this should probably throw like in the 'else' case (so first check on 'AqlFunctionAttribute'?)
-                };
-
-                pushObjectAsArgument = true;
-            }
             else
             {
                 var aqlFunction = expression.Method.GetCustomAttribute<AqlFunctionAttribute>();
@@ -174,27 +153,7 @@ namespace Core.Arango.Linq.Query
                     ModelVisitor.QueryText.Append(argumentSeprator);
             }
 
-            if(expression.Method.DeclaringType == typeof(DateTime) && methodName == "DATE_ADD")
-            {
-                ModelVisitor.QueryText.Append(argumentSeprator);
-
-                string parameter = null;
-
-                parameter = expression.Method.Name switch
-                {
-                    "AddYears" => " \"y\" ",
-                    "AddMonths" => " \"m\" ",
-                    "AddDays" => " \"d\" ",
-                    "AddHours" => " \"h\" ",
-                    "AddMinutes" => " \"i\" ",
-                    "AddSeconds" => " \"s\" ",
-                    "AddMilliseconds" => " \"f\" ",
-                    "" => expression.Method.Name
-                };
-
-                ModelVisitor.QueryText.Append(parameter);
-            }
-            else if (expression.Method.DeclaringType == typeof(string) && expression.Method.Name == "IndexOf")
+            if (expression.Method.DeclaringType == typeof(string) && expression.Method.Name == "IndexOf")
             {
                 ModelVisitor.QueryText.Append(argumentSeprator);
 

--- a/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
+++ b/Core.Arango/Linq/Query/ArangoExpressionTreeVisitor.cs
@@ -100,8 +100,8 @@ namespace Core.Arango.Linq.Query
                     "ToUpper" => "UPPER",
                     "" => expression.Method.Name // TODO : this should probably throw like in the 'else' case (so first check on 'AqlFunctionAttribute'?)
                 };
-
-                pushObjectAsArgument = true;
+                if(methodName != "CONCAT")
+                    pushObjectAsArgument = true;
             }
             else if (expression.Method.DeclaringType == typeof(DateTime))
             {
@@ -351,6 +351,18 @@ namespace Core.Arango.Linq.Query
 
                 ModelVisitor.QueryText.AppendFormat(
                     LinqUtility.ResolvePropertyName($"{prefix}_{expression.Member.Name}"));
+            }
+            else if (expression.Type.Name == "Int32" && member.Type.Name == "String")
+            {
+                var lenMember = expression as MemberExpression;
+                var lenMemberName = lenMember.Member.Name;
+                if(lenMemberName == "Length")
+                {
+                    ModelVisitor.QueryText.AppendFormat(" {0}( ", lenMemberName.ToUpper());
+                    Visit(member);
+                    ModelVisitor.QueryText.Append(" ) ");
+                }
+
             }
             else
             {


### PR DESCRIPTION
LINQ method changes as discussed in https://github.com/coronabytes/dotnet-arangodb/issues/36 .

It seems like there was a small overlap in work, as we didn't notice your commit of 31 December. Other than that we added some tests + support for `Equals`. An overview:

# String Methods
Added support for the next String Methods:
- Concat (<span style="color:green">Passing</span>)
- Contains (<span style="color:green">Passing</span>)
- IndexOf (<span style="color:green">Passing</span>)
- Replace (<span style="color:green">Passing</span>)
- Split (<span style="color:green">Passing</span>)
- Substring (<span style="color:green">Passing</span>)
- ToLower (<span style="color:green">Passing</span>)
- ToUpper (<span style="color:green">Passing</span>)
- Trim (<span style="color:red">Not Passing</span>)
- TrimEnd (<span style="color:green">Passing</span>)
- TrimStart (<span style="color:green">Passing</span>)

All of them work, expect for the TRIM function, as the AQL method TRIM doesn't accept a collection of characters for trimming, unlike the LTRIM and RTRIM methods. We've created an issue in the ArangoDB github for now.

# Equals method
Added support for the Equals method (for comparing generic objects, as the == operand can't be used on those).

# Properties that can be translated as methods
Added support for translating the String property Length to it's AQL equivalent.
- Length (<span style="color:green">Passing</span>)

# Basic Linq Methods tests
Added a new file for testing different Linq methods that need fixing, like GroupBy, Any, and others. Most of them are not passing. There's a notable mention for the Average method when working with decimal values (check the Average test for more details).
- All (<span style="color:red">Not Passing</span>)
- Any (<span style="color:red">Not Passing</span>)
- Average (<span style="color:red">Not Passing</span>)
- Contains (<span style="color:red">Not Passing</span>)
- Distinct (<span style="color:red">Not Passing</span>)
- Except (<span style="color:red">Not Passing</span>)
- GroupBy (<span style="color:red">Not Passing</span>)
- GroupJoin (<span style="color:red">Not Passing</span>)
- Intersect (<span style="color:red">Not Passing</span>)
- Join (<span style="color:red">Not Passing</span>)
- Max (<span style="color:green">Passing</span>)
- Min (<span style="color:green">Passing</span>)
- SameVariableChained (<span style="color:red">Not Passing</span>)
- Sum (<span style="color:green">Passing</span>)
- Union (<span style="color:red">Not Passing</span>)

We are working on these in a separate branch. Let me know if you have any suggestions to guide the implementation. After this PR is merged we'll open another one with the next batch of LINQ methods.

Thanks to @mrjuanblack for his hard work.