### PR TITLE
Improved readme code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ var arango = new ArangoContext("Server=http://localhost:8529;");
 var arango = new ArangoContext("Server=http://localhost:8529;Realm=myproject;User=root;Password=;",
 new ArangoConfiguration
 {
-    Serializer = new ArangoNewtonsoftSerializer(new ArangoNewtonsoftCamelCaseContractResolver())
+    Serializer = new ArangoJsonSerializer(new ArangoJsonDefaultPolicy())
 });
 ```
 - For AspNetCore DI extension is available:
@@ -160,7 +160,7 @@ await arango.Document.UpdateAsync("database", "collection", new ComplexEntity {
 var col = "collection";
 var list = new List<int> {1, 2, 3};
 
-var result = await arango.Query.ExecuteAsync<JObject>("database",
+var result = await arango.Query.ExecuteAsync<JsonObject>("database",
   $"FOR c IN {col:@} FILTER c.SomeValue IN {list} RETURN c");
 ```
 results in AQL injection save syntax:
@@ -183,7 +183,7 @@ FormattableString forPart = $"FOR c IN {collectionName:@}";
 FormattableString filterPart = $"FILTER c.SomeValue IN {list}";
 FormattableString returnPart = $"RETURN c";
 
-var result = await arango.Query.ExecuteAsync<JObject>("database",
+var result = await arango.Query.ExecuteAsync<JsonObject>("database",
   $"{forPart} {filterPart} {returnPart}");
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ await arango.Document.UpdateAsync("database", "collection", new ComplexEntity {
 });
 ```
 
-## Query with bind vars through string interpolation
+## Query with bindable parameters through string interpolation
 ```csharp
 var col = "collection";
 var list = new List<int> {1, 2, 3};
@@ -185,6 +185,12 @@ FormattableString returnPart = $"RETURN c";
 
 var result = await arango.Query.ExecuteAsync<JObject>("database",
   $"{forPart} {filterPart} {returnPart}");
+```
+
+**Notice**  
+If using multiple `FormattableString` variables, every single injected string variable needs to be of type `FormattableString` or Arango will return an error stating:  
+```exception
+AQL: syntax error, unexpected bind parameter near @P3
 ```
 
 ## Query with async enumerator

--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ await arango.Document.UpdateAsync("database", "collection", new ComplexEntity {
 });
 ```
 
-## Query with bindable parameters through string interpolation
+## Custom Query
+### Bindable parameters
 ```csharp
 var col = "collection";
 var list = new List<int> {1, 2, 3};
@@ -206,7 +207,7 @@ Results in AQL injection save syntax:
 ```
 for collections parameters, formats `'@'`, `'C'` and `'c'` are supported. They all mean the same format.
 
-- Complex queries can be built from parts:
+### Split queries into parts
 ```csharp
 var collectionName = "collection";
 var list = new List<int> {1, 2, 3};
@@ -229,6 +230,29 @@ If using multiple `FormattableString` variables, every single injected string va
 ```exception
 AQL: syntax error, unexpected bind parameter near @P3
 ```
+
+### Inject data into Arango return
+```csharp
+public class MyClass2
+{
+    public MyClass Data { get; set; }
+    public double CustomData { get; set; }
+}
+
+var collectionName = "collection";
+var list = new List<int> {1, 2, 3};
+var pointA = "[48.157741, 11.503159]";
+var pointB = "[48.155739, 11.491601]";
+
+FormattableString forPart = $"FOR c IN {collectionName:@}";
+FormattableString filterPart = $"FILTER c.SomeValue IN {list}";
+FormattableString letDistance = $"LET distance = GEO_DISTANCE({pointA}, {pointB})";
+FormattableString returnPart = $"RETURN {{Data: c, Distance: distance}}";
+
+var result = await arango.Query.ExecuteAsync<MyClass2>("database",
+  $"{forPart} {filterPart} {letDistance} {returnPart}");
+```
+
 
 ## Query with async enumerator
 ```csharp


### PR DESCRIPTION
General improvements to the readme code examples:
  - Add Custom Query with Arango return injection
  - Improve examples for database context serializer pascal case and camel case options
  - Set System.Text.Json as default  
  - General layout improvements (e.g. indentation of code blocks on enumeration, Linq hierarchy level)