### PR TITLE
Exclusive lock option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4

--- a/Core.Arango.sln
+++ b/Core.Arango.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34723.18
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core.Arango", "Core.Arango\Core.Arango.csproj", "{6B8D05CE-CCB7-4FC4-A85F-EADDEF305999}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core.Arango.Tests", "Core.Arango.Tests\Core.Arango.Tests.csproj", "{F31E2F80-FFFB-43DA-9C6B-971B854D1E35}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{13D67C1C-3066-4412-A1F6-9C9AD13B7C81}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Core.Arango/Core.Arango.csproj
+++ b/Core.Arango/Core.Arango.csproj
@@ -9,7 +9,7 @@
     <PackageReleaseNotes></PackageReleaseNotes>
     <Description>.NET driver for ArangoDB with support for database per tenant deployments</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Copyright>Andreas Dominik Jung</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIcon>ArangoDB.png</PackageIcon>

--- a/Core.Arango/Core.Arango.xml
+++ b/Core.Arango/Core.Arango.xml
@@ -2731,32 +2731,32 @@
             </param>
             <param name="cancellationToken"></param>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.CreateManyAsync``2(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{Core.Arango.Protocol.ArangoOverwriteMode},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.CreateManyAsync``2(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{Core.Arango.Protocol.ArangoOverwriteMode},System.Threading.CancellationToken)">
             <summary>
                 Creates multiple documents
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.CreateManyAsync``1(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{Core.Arango.Protocol.ArangoOverwriteMode},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.CreateManyAsync``1(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{Core.Arango.Protocol.ArangoOverwriteMode},System.Threading.CancellationToken)">
             <summary>
                 Creates multiple documents
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.CreateAsync``2(Core.Arango.ArangoHandle,System.String,``0,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{Core.Arango.Protocol.ArangoOverwriteMode},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.CreateAsync``2(Core.Arango.ArangoHandle,System.String,``0,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{Core.Arango.Protocol.ArangoOverwriteMode},System.Threading.CancellationToken)">
             <summary>
                 Create document
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.CreateAsync``1(Core.Arango.ArangoHandle,System.String,``0,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{Core.Arango.Protocol.ArangoOverwriteMode},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.CreateAsync``1(Core.Arango.ArangoHandle,System.String,``0,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{Core.Arango.Protocol.ArangoOverwriteMode},System.Threading.CancellationToken)">
             <summary>
                 Create document
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.DeleteManyAsync``2(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.DeleteManyAsync``2(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
             <summary>
                 Removes multiple documents
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.DeleteAsync``1(Core.Arango.ArangoHandle,System.String,System.String,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.String,System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.DeleteAsync``1(Core.Arango.ArangoHandle,System.String,System.String,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.String,System.Threading.CancellationToken)">
             <summary>
                 Removes single document by key
             </summary>
@@ -2771,42 +2771,42 @@
                 Bulk import
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.ReplaceManyAsync``2(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.ReplaceManyAsync``2(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
             <summary>
                 Replaces multiple documents
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.ReplaceManyAsync``1(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.ReplaceManyAsync``1(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
             <summary>
                 Replaces multiple documents
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.ReplaceAsync``2(Core.Arango.ArangoHandle,System.String,``0,System.Boolean,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.ReplaceAsync``2(Core.Arango.ArangoHandle,System.String,``0,System.Boolean,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
             <summary>
                 Replace single document
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.ReplaceAsync``1(Core.Arango.ArangoHandle,System.String,``0,System.Boolean,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.ReplaceAsync``1(Core.Arango.ArangoHandle,System.String,``0,System.Boolean,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
             <summary>
                 Replace single document
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.UpdateManyAsync``1(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.UpdateManyAsync``1(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
             <summary>
                 Updates multiple documents
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.UpdateManyAsync``2(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.UpdateManyAsync``2(Core.Arango.ArangoHandle,System.String,System.Collections.Generic.IEnumerable{``0},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
             <summary>
                 Updates multiple documents
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.UpdateAsync``1(Core.Arango.ArangoHandle,System.String,``0,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.UpdateAsync``1(Core.Arango.ArangoHandle,System.String,``0,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
             <summary>
                 Updates single document
             </summary>
         </member>
-        <member name="M:Core.Arango.Modules.IArangoDocumentModule.UpdateAsync``2(Core.Arango.ArangoHandle,System.String,``0,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
+        <member name="M:Core.Arango.Modules.IArangoDocumentModule.UpdateAsync``2(Core.Arango.ArangoHandle,System.String,``0,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Threading.CancellationToken)">
             <summary>
                 Updates single document
             </summary>

--- a/Core.Arango/Modules/IArangoDocumentModule.cs
+++ b/Core.Arango/Modules/IArangoDocumentModule.cs
@@ -62,8 +62,9 @@ namespace Core.Arango.Modules
             bool? mergeObjects = null,
             bool? returnOld = null,
             bool? returnNew = null,
-            bool? silent = null,
-            ArangoOverwriteMode? overwriteMode = null,
+						bool? silent = null,
+						bool? exclusive = null,
+						ArangoOverwriteMode? overwriteMode = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -78,7 +79,8 @@ namespace Core.Arango.Modules
             bool? returnOld = null,
             bool? returnNew = null,
             bool? silent = null,
-            ArangoOverwriteMode? overwriteMode = null,
+						bool? exclusive = null,
+						ArangoOverwriteMode? overwriteMode = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -92,7 +94,8 @@ namespace Core.Arango.Modules
             bool? returnOld = null,
             bool? returnNew = null,
             bool? silent = null,
-            ArangoOverwriteMode? overwriteMode = null,
+						bool? exclusive = null,
+						ArangoOverwriteMode? overwriteMode = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -106,22 +109,23 @@ namespace Core.Arango.Modules
             bool? returnOld = null,
             bool? returnNew = null,
             bool? silent = null,
-            ArangoOverwriteMode? overwriteMode = null,
+						bool? exclusive = null,
+						ArangoOverwriteMode? overwriteMode = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Removes multiple documents
         /// </summary>
         Task<List<ArangoUpdateResult<TR>>> DeleteManyAsync<T, TR>(ArangoHandle database, string collection,
-            IEnumerable<T> docs, bool? waitForSync = null, bool? returnOld = null, bool? ignoreRevs = null,
+            IEnumerable<T> docs, bool? waitForSync = null, bool? returnOld = null, bool? ignoreRevs = null, bool? exclusive = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Removes single document by key
         /// </summary>
         Task<ArangoUpdateResult<TR>> DeleteAsync<TR>(ArangoHandle database, string collection, string key,
-            bool? waitForSync = null, bool? returnOld = null, bool? silent = null, string ifMatch = null,
-            CancellationToken cancellationToken = default);
+            bool? waitForSync = null, bool? returnOld = null, bool? silent = null, bool? exclusive = null, 
+            string ifMatch = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Export all documents in batches from a collection (Query.ExecuteStreamAsync)
@@ -140,31 +144,31 @@ namespace Core.Arango.Modules
         ///     Replaces multiple documents
         /// </summary>
         Task<List<ArangoUpdateResult<TR>>> ReplaceManyAsync<T, TR>(ArangoHandle database, string collection,
-            IEnumerable<T> docs, bool? waitForSync = null, bool? returnOld = null, bool? returnNew = null,
-            bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default);
+            IEnumerable<T> docs, bool? waitForSync = null, bool? returnOld = null, bool? returnNew = null, 
+						bool? ignoreRevs = null, bool? exclusive = null,
+						CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Replaces multiple documents
         /// </summary>
         Task<List<ArangoUpdateResult<ArangoVoid>>> ReplaceManyAsync<T>(ArangoHandle database, string collection,
             IEnumerable<T> docs, bool? waitForSync = null, bool? returnOld = null, bool? returnNew = null,
-            bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default);
+            bool? ignoreRevs = null, bool? exclusive = null,
+						CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Replace single document
         /// </summary>
         Task<ArangoUpdateResult<TR>> ReplaceAsync<T, TR>(ArangoHandle database, string collection, T doc,
             bool waitForSync = false, bool? returnOld = null, bool? returnNew = null, bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default);
+						bool? exclusive = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Replace single document
         /// </summary>
         Task<ArangoUpdateResult<ArangoVoid>> ReplaceAsync<T>(ArangoHandle database, string collection, T doc,
             bool waitForSync = false, bool? returnOld = null, bool? returnNew = null, bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default);
+						bool? exclusive = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Updates multiple documents
@@ -172,7 +176,7 @@ namespace Core.Arango.Modules
         Task<List<ArangoUpdateResult<ArangoVoid>>> UpdateManyAsync<T>(ArangoHandle database, string collection,
             IEnumerable<T> docs, bool? waitForSync = null, bool? keepNull = null, bool? mergeObjects = null,
             bool? returnOld = null, bool? returnNew = null, bool? silent = null, bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default);
+						bool? exclusive = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Updates multiple documents
@@ -180,22 +184,22 @@ namespace Core.Arango.Modules
         Task<List<ArangoUpdateResult<TR>>> UpdateManyAsync<T, TR>(ArangoHandle database, string collection,
             IEnumerable<T> docs, bool? waitForSync = null, bool? keepNull = null, bool? mergeObjects = null,
             bool? returnOld = null, bool? returnNew = null, bool? silent = null, bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default);
+						bool? exclusive = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Updates single document
         /// </summary>
         Task<ArangoUpdateResult<ArangoVoid>> UpdateAsync<T>(ArangoHandle database, string collection, T doc,
             bool? waitForSync = null, bool? keepNull = null, bool? mergeObjects = null, bool? returnOld = null,
-            bool? returnNew = null, bool? silent = null, bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default);
+            bool? returnNew = null, bool? silent = null, bool? ignoreRevs = null, bool? exclusive = null,
+						CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Updates single document
         /// </summary>
         Task<ArangoUpdateResult<TR>> UpdateAsync<T, TR>(ArangoHandle database, string collection, T doc,
             bool? waitForSync = null, bool? keepNull = null, bool? mergeObjects = null, bool? returnOld = null,
-            bool? returnNew = null, bool? silent = null, bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default);
+            bool? returnNew = null, bool? silent = null, bool? ignoreRevs = null, bool? exclusive = null,
+						CancellationToken cancellationToken = default);
     }
 }

--- a/Core.Arango/Modules/IArangoDocumentModule.cs
+++ b/Core.Arango/Modules/IArangoDocumentModule.cs
@@ -62,9 +62,9 @@ namespace Core.Arango.Modules
             bool? mergeObjects = null,
             bool? returnOld = null,
             bool? returnNew = null,
-						bool? silent = null,
-						bool? exclusive = null,
-						ArangoOverwriteMode? overwriteMode = null,
+            bool? silent = null,
+            bool? exclusive = null,
+            ArangoOverwriteMode? overwriteMode = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace Core.Arango.Modules
             bool? returnOld = null,
             bool? returnNew = null,
             bool? silent = null,
-						bool? exclusive = null,
-						ArangoOverwriteMode? overwriteMode = null,
+            bool? exclusive = null,
+            ArangoOverwriteMode? overwriteMode = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -94,8 +94,8 @@ namespace Core.Arango.Modules
             bool? returnOld = null,
             bool? returnNew = null,
             bool? silent = null,
-						bool? exclusive = null,
-						ArangoOverwriteMode? overwriteMode = null,
+            bool? exclusive = null,
+            ArangoOverwriteMode? overwriteMode = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -109,8 +109,8 @@ namespace Core.Arango.Modules
             bool? returnOld = null,
             bool? returnNew = null,
             bool? silent = null,
-						bool? exclusive = null,
-						ArangoOverwriteMode? overwriteMode = null,
+            bool? exclusive = null,
+            ArangoOverwriteMode? overwriteMode = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Core.Arango.Modules
         ///     Removes single document by key
         /// </summary>
         Task<ArangoUpdateResult<TR>> DeleteAsync<TR>(ArangoHandle database, string collection, string key,
-            bool? waitForSync = null, bool? returnOld = null, bool? silent = null, bool? exclusive = null, 
+            bool? waitForSync = null, bool? returnOld = null, bool? silent = null, bool? exclusive = null,
             string ifMatch = null, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -144,9 +144,9 @@ namespace Core.Arango.Modules
         ///     Replaces multiple documents
         /// </summary>
         Task<List<ArangoUpdateResult<TR>>> ReplaceManyAsync<T, TR>(ArangoHandle database, string collection,
-            IEnumerable<T> docs, bool? waitForSync = null, bool? returnOld = null, bool? returnNew = null, 
-						bool? ignoreRevs = null, bool? exclusive = null,
-						CancellationToken cancellationToken = default);
+            IEnumerable<T> docs, bool? waitForSync = null, bool? returnOld = null, bool? returnNew = null,
+            bool? ignoreRevs = null, bool? exclusive = null,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Replaces multiple documents
@@ -154,21 +154,21 @@ namespace Core.Arango.Modules
         Task<List<ArangoUpdateResult<ArangoVoid>>> ReplaceManyAsync<T>(ArangoHandle database, string collection,
             IEnumerable<T> docs, bool? waitForSync = null, bool? returnOld = null, bool? returnNew = null,
             bool? ignoreRevs = null, bool? exclusive = null,
-						CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Replace single document
         /// </summary>
         Task<ArangoUpdateResult<TR>> ReplaceAsync<T, TR>(ArangoHandle database, string collection, T doc,
             bool waitForSync = false, bool? returnOld = null, bool? returnNew = null, bool? ignoreRevs = null,
-						bool? exclusive = null, CancellationToken cancellationToken = default);
+            bool? exclusive = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Replace single document
         /// </summary>
         Task<ArangoUpdateResult<ArangoVoid>> ReplaceAsync<T>(ArangoHandle database, string collection, T doc,
             bool waitForSync = false, bool? returnOld = null, bool? returnNew = null, bool? ignoreRevs = null,
-						bool? exclusive = null, CancellationToken cancellationToken = default);
+            bool? exclusive = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Updates multiple documents
@@ -176,7 +176,7 @@ namespace Core.Arango.Modules
         Task<List<ArangoUpdateResult<ArangoVoid>>> UpdateManyAsync<T>(ArangoHandle database, string collection,
             IEnumerable<T> docs, bool? waitForSync = null, bool? keepNull = null, bool? mergeObjects = null,
             bool? returnOld = null, bool? returnNew = null, bool? silent = null, bool? ignoreRevs = null,
-						bool? exclusive = null, CancellationToken cancellationToken = default);
+            bool? exclusive = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Updates multiple documents
@@ -184,7 +184,7 @@ namespace Core.Arango.Modules
         Task<List<ArangoUpdateResult<TR>>> UpdateManyAsync<T, TR>(ArangoHandle database, string collection,
             IEnumerable<T> docs, bool? waitForSync = null, bool? keepNull = null, bool? mergeObjects = null,
             bool? returnOld = null, bool? returnNew = null, bool? silent = null, bool? ignoreRevs = null,
-						bool? exclusive = null, CancellationToken cancellationToken = default);
+            bool? exclusive = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Updates single document
@@ -192,7 +192,7 @@ namespace Core.Arango.Modules
         Task<ArangoUpdateResult<ArangoVoid>> UpdateAsync<T>(ArangoHandle database, string collection, T doc,
             bool? waitForSync = null, bool? keepNull = null, bool? mergeObjects = null, bool? returnOld = null,
             bool? returnNew = null, bool? silent = null, bool? ignoreRevs = null, bool? exclusive = null,
-						CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Updates single document
@@ -200,6 +200,6 @@ namespace Core.Arango.Modules
         Task<ArangoUpdateResult<TR>> UpdateAsync<T, TR>(ArangoHandle database, string collection, T doc,
             bool? waitForSync = null, bool? keepNull = null, bool? mergeObjects = null, bool? returnOld = null,
             bool? returnNew = null, bool? silent = null, bool? ignoreRevs = null, bool? exclusive = null,
-						CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default);
     }
 }

--- a/Core.Arango/Modules/Internal/ArangoDocumentModule.cs
+++ b/Core.Arango/Modules/Internal/ArangoDocumentModule.cs
@@ -62,13 +62,13 @@ namespace Core.Arango.Modules.Internal
             if (keepNull.HasValue)
                 parameter.Add("keepNull", keepNull.Value.ToString().ToLowerInvariant());
 
-			      if (mergeObjects.HasValue)
-				        parameter.Add("mergeObjects", mergeObjects.Value.ToString().ToLowerInvariant());
+            if (mergeObjects.HasValue)
+                parameter.Add("mergeObjects", mergeObjects.Value.ToString().ToLowerInvariant());
 
-			      if (exclusive.HasValue)
-				        parameter.Add("exclusive", mergeObjects.Value.ToString().ToLowerInvariant());
+            if (exclusive.HasValue)
+                parameter.Add("exclusive", mergeObjects.Value.ToString().ToLowerInvariant());
 
-			      if (returnOld.HasValue)
+            if (returnOld.HasValue)
                 parameter.Add("returnOld", returnOld.Value.ToString().ToLowerInvariant());
 
             if (returnNew.HasValue)
@@ -114,7 +114,7 @@ namespace Core.Arango.Modules.Internal
             T doc,
             bool? waitForSync = null, bool? keepNull = null,
             bool? mergeObjects = null, bool? returnOld = null, bool? returnNew = null, bool? silent = null,
-						bool? exclusive = null, ArangoOverwriteMode? overwriteMode = null, CancellationToken cancellationToken = default)
+                        bool? exclusive = null, ArangoOverwriteMode? overwriteMode = null, CancellationToken cancellationToken = default)
         {
             var res = await CreateManyAsync<T, ArangoVoid>(database, collection, new List<T> { doc }, waitForSync,
                 keepNull, mergeObjects,
@@ -145,8 +145,8 @@ namespace Core.Arango.Modules.Internal
             bool? waitForSync = null,
             bool? returnOld = null,
             bool? silent = null,
-						bool? exclusive = null,
-						string ifMatch = null,
+                        bool? exclusive = null,
+                        string ifMatch = null,
             CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
@@ -181,8 +181,8 @@ namespace Core.Arango.Modules.Internal
             bool? waitForSync = null,
             bool? returnOld = null,
             bool? ignoreRevs = null,
-						bool? exclusive = null,
-						CancellationToken cancellationToken = default)
+                        bool? exclusive = null,
+                        CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
 
@@ -212,8 +212,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-						bool? exclusive = null,
-						CancellationToken cancellationToken = default)
+                        bool? exclusive = null,
+                        CancellationToken cancellationToken = default)
         {
             return await UpdateManyAsync<T, ArangoVoid>(database, collection, docs, waitForSync, keepNull,
                 mergeObjects,
@@ -229,8 +229,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-						bool? exclusive = null,
-						CancellationToken cancellationToken = default)
+                        bool? exclusive = null,
+                        CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
 
@@ -274,8 +274,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-						bool? exclusive = null,
-						CancellationToken cancellationToken = default)
+                        bool? exclusive = null,
+                        CancellationToken cancellationToken = default)
         {
             var res = await UpdateManyAsync<T, ArangoVoid>(database, collection,
                 new List<T> { doc }, waitForSync, keepNull, mergeObjects,
@@ -293,8 +293,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-						bool? exclusive = null,
-						CancellationToken cancellationToken = default)
+                        bool? exclusive = null,
+                        CancellationToken cancellationToken = default)
         {
             var res = await UpdateManyAsync<T, TR>(database, collection,
                 new List<T> { doc }, waitForSync, keepNull, mergeObjects,
@@ -309,8 +309,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-						bool? exclusive = null,
-						CancellationToken cancellationToken = default)
+                        bool? exclusive = null,
+                        CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
 
@@ -319,7 +319,7 @@ namespace Core.Arango.Modules.Internal
 
             if (returnOld.HasValue)
                 parameter.Add("returnOld", returnOld.Value.ToString().ToLowerInvariant());
-            
+
             if (returnNew.HasValue)
                 parameter.Add("returnNew", returnNew.Value.ToString().ToLowerInvariant());
 
@@ -342,8 +342,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-						bool? exclusive = null,
-						CancellationToken cancellationToken = default)
+                        bool? exclusive = null,
+                        CancellationToken cancellationToken = default)
         {
             return await ReplaceManyAsync<T, ArangoVoid>(database, collection, docs,
                 waitForSync, returnOld, returnNew, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);
@@ -355,8 +355,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-						bool? exclusive = null,
-						CancellationToken cancellationToken = default)
+                        bool? exclusive = null,
+                        CancellationToken cancellationToken = default)
         {
             var res = await ReplaceManyAsync<T, TR>(database, collection, new List<T> { doc },
                 waitForSync, returnOld, returnNew, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);
@@ -370,8 +370,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-						bool? exclusive = null,
-						CancellationToken cancellationToken = default)
+                        bool? exclusive = null,
+                        CancellationToken cancellationToken = default)
         {
             var res = await ReplaceManyAsync<T, ArangoVoid>(database, collection, new List<T> { doc },
                 waitForSync, returnOld, returnNew, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);

--- a/Core.Arango/Modules/Internal/ArangoDocumentModule.cs
+++ b/Core.Arango/Modules/Internal/ArangoDocumentModule.cs
@@ -114,7 +114,7 @@ namespace Core.Arango.Modules.Internal
             T doc,
             bool? waitForSync = null, bool? keepNull = null,
             bool? mergeObjects = null, bool? returnOld = null, bool? returnNew = null, bool? silent = null,
-                        bool? exclusive = null, ArangoOverwriteMode? overwriteMode = null, CancellationToken cancellationToken = default)
+            bool? exclusive = null, ArangoOverwriteMode? overwriteMode = null, CancellationToken cancellationToken = default)
         {
             var res = await CreateManyAsync<T, ArangoVoid>(database, collection, new List<T> { doc }, waitForSync,
                 keepNull, mergeObjects,
@@ -145,8 +145,8 @@ namespace Core.Arango.Modules.Internal
             bool? waitForSync = null,
             bool? returnOld = null,
             bool? silent = null,
-                        bool? exclusive = null,
-                        string ifMatch = null,
+            bool? exclusive = null,
+            string ifMatch = null,
             CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
@@ -181,8 +181,8 @@ namespace Core.Arango.Modules.Internal
             bool? waitForSync = null,
             bool? returnOld = null,
             bool? ignoreRevs = null,
-                        bool? exclusive = null,
-                        CancellationToken cancellationToken = default)
+            bool? exclusive = null,
+            CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
 
@@ -212,8 +212,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-                        bool? exclusive = null,
-                        CancellationToken cancellationToken = default)
+            bool? exclusive = null,
+            CancellationToken cancellationToken = default)
         {
             return await UpdateManyAsync<T, ArangoVoid>(database, collection, docs, waitForSync, keepNull,
                 mergeObjects,
@@ -229,8 +229,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-                        bool? exclusive = null,
-                        CancellationToken cancellationToken = default)
+            bool? exclusive = null,
+            CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
 
@@ -274,8 +274,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-                        bool? exclusive = null,
-                        CancellationToken cancellationToken = default)
+            bool? exclusive = null,
+            CancellationToken cancellationToken = default)
         {
             var res = await UpdateManyAsync<T, ArangoVoid>(database, collection,
                 new List<T> { doc }, waitForSync, keepNull, mergeObjects,
@@ -293,8 +293,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-                        bool? exclusive = null,
-                        CancellationToken cancellationToken = default)
+            bool? exclusive = null,
+            CancellationToken cancellationToken = default)
         {
             var res = await UpdateManyAsync<T, TR>(database, collection,
                 new List<T> { doc }, waitForSync, keepNull, mergeObjects,
@@ -309,8 +309,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-                        bool? exclusive = null,
-                        CancellationToken cancellationToken = default)
+            bool? exclusive = null,
+            CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
 
@@ -342,8 +342,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-                        bool? exclusive = null,
-                        CancellationToken cancellationToken = default)
+            bool? exclusive = null,
+            CancellationToken cancellationToken = default)
         {
             return await ReplaceManyAsync<T, ArangoVoid>(database, collection, docs,
                 waitForSync, returnOld, returnNew, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);
@@ -355,8 +355,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-                        bool? exclusive = null,
-                        CancellationToken cancellationToken = default)
+            bool? exclusive = null,
+            CancellationToken cancellationToken = default)
         {
             var res = await ReplaceManyAsync<T, TR>(database, collection, new List<T> { doc },
                 waitForSync, returnOld, returnNew, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);
@@ -370,8 +370,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-                        bool? exclusive = null,
-                        CancellationToken cancellationToken = default)
+            bool? exclusive = null,
+            CancellationToken cancellationToken = default)
         {
             var res = await ReplaceManyAsync<T, ArangoVoid>(database, collection, new List<T> { doc },
                 waitForSync, returnOld, returnNew, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);

--- a/Core.Arango/Modules/Internal/ArangoDocumentModule.cs
+++ b/Core.Arango/Modules/Internal/ArangoDocumentModule.cs
@@ -51,7 +51,7 @@ namespace Core.Arango.Modules.Internal
         public async Task<List<ArangoUpdateResult<TR>>> CreateManyAsync<T, TR>(ArangoHandle database,
             string collection, IEnumerable<T> docs, bool? waitForSync = null,
             bool? keepNull = null, bool? mergeObjects = null, bool? returnOld = null, bool? returnNew = null,
-            bool? silent = null, ArangoOverwriteMode? overwriteMode = null,
+            bool? silent = null, bool? exclusive = null, ArangoOverwriteMode? overwriteMode = null,
             CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
@@ -62,10 +62,13 @@ namespace Core.Arango.Modules.Internal
             if (keepNull.HasValue)
                 parameter.Add("keepNull", keepNull.Value.ToString().ToLowerInvariant());
 
-            if (mergeObjects.HasValue)
-                parameter.Add("mergeObjects", mergeObjects.Value.ToString().ToLowerInvariant());
+			      if (mergeObjects.HasValue)
+				        parameter.Add("mergeObjects", mergeObjects.Value.ToString().ToLowerInvariant());
 
-            if (returnOld.HasValue)
+			      if (exclusive.HasValue)
+				        parameter.Add("exclusive", mergeObjects.Value.ToString().ToLowerInvariant());
+
+			      if (returnOld.HasValue)
                 parameter.Add("returnOld", returnOld.Value.ToString().ToLowerInvariant());
 
             if (returnNew.HasValue)
@@ -86,23 +89,23 @@ namespace Core.Arango.Modules.Internal
         public async Task<List<ArangoUpdateResult<ArangoVoid>>> CreateManyAsync<T>(ArangoHandle database,
             string collection, IEnumerable<T> docs, bool? waitForSync = null,
             bool? keepNull = null, bool? mergeObjects = null, bool? returnOld = null, bool? returnNew = null,
-            bool? silent = null, ArangoOverwriteMode? overwriteMode = null,
+            bool? silent = null, bool? exclusive = null, ArangoOverwriteMode? overwriteMode = null,
             CancellationToken cancellationToken = default)
         {
             return await CreateManyAsync<T, ArangoVoid>(database, collection, docs, waitForSync, keepNull,
                 mergeObjects,
-                returnOld, returnNew, silent, overwriteMode, cancellationToken).ConfigureAwait(false);
+                returnOld, returnNew, silent, exclusive, overwriteMode, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ArangoUpdateResult<TR>> CreateAsync<T, TR>(ArangoHandle database, string collection, T doc,
             bool? waitForSync = null,
             bool? keepNull = null, bool? mergeObjects = null, bool? returnOld = null, bool? returnNew = null,
-            bool? silent = null, ArangoOverwriteMode? overwriteMode = null,
+            bool? silent = null, bool? exclusive = null, ArangoOverwriteMode? overwriteMode = null,
             CancellationToken cancellationToken = default)
         {
             var res = await CreateManyAsync<T, TR>(database, collection, new List<T> { doc }, waitForSync, keepNull,
                 mergeObjects,
-                returnOld, returnNew, silent, overwriteMode, cancellationToken).ConfigureAwait(false);
+                returnOld, returnNew, silent, exclusive, overwriteMode, cancellationToken).ConfigureAwait(false);
 
             return res?.SingleOrDefault();
         }
@@ -111,11 +114,11 @@ namespace Core.Arango.Modules.Internal
             T doc,
             bool? waitForSync = null, bool? keepNull = null,
             bool? mergeObjects = null, bool? returnOld = null, bool? returnNew = null, bool? silent = null,
-            ArangoOverwriteMode? overwriteMode = null, CancellationToken cancellationToken = default)
+						bool? exclusive = null, ArangoOverwriteMode? overwriteMode = null, CancellationToken cancellationToken = default)
         {
             var res = await CreateManyAsync<T, ArangoVoid>(database, collection, new List<T> { doc }, waitForSync,
                 keepNull, mergeObjects,
-                returnOld, returnNew, silent, overwriteMode, cancellationToken);
+                returnOld, returnNew, silent, exclusive, overwriteMode, cancellationToken);
 
             return res?.SingleOrDefault();
         }
@@ -142,7 +145,8 @@ namespace Core.Arango.Modules.Internal
             bool? waitForSync = null,
             bool? returnOld = null,
             bool? silent = null,
-            string ifMatch = null,
+						bool? exclusive = null,
+						string ifMatch = null,
             CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
@@ -152,6 +156,9 @@ namespace Core.Arango.Modules.Internal
 
             if (returnOld.HasValue)
                 parameter.Add("returnOld", returnOld.Value.ToString().ToLowerInvariant());
+
+            if (exclusive.HasValue)
+                parameter.Add("exclusive", exclusive.Value.ToString().ToLowerInvariant());
 
             if (silent.HasValue)
                 parameter.Add("silent", silent.Value.ToString().ToLowerInvariant());
@@ -174,7 +181,8 @@ namespace Core.Arango.Modules.Internal
             bool? waitForSync = null,
             bool? returnOld = null,
             bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default)
+						bool? exclusive = null,
+						CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
 
@@ -204,11 +212,12 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default)
+						bool? exclusive = null,
+						CancellationToken cancellationToken = default)
         {
             return await UpdateManyAsync<T, ArangoVoid>(database, collection, docs, waitForSync, keepNull,
                 mergeObjects,
-                returnOld, returnNew, silent, ignoreRevs, cancellationToken).ConfigureAwait(false);
+                returnOld, returnNew, silent, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<List<ArangoUpdateResult<TR>>> UpdateManyAsync<T, TR>(ArangoHandle database,
@@ -220,7 +229,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default)
+						bool? exclusive = null,
+						CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
 
@@ -245,6 +255,9 @@ namespace Core.Arango.Modules.Internal
             if (ignoreRevs.HasValue)
                 parameter.Add("ignoreRevs", ignoreRevs.Value.ToString().ToLowerInvariant());
 
+            if (exclusive.HasValue)
+                parameter.Add("exclusive", ignoreRevs.Value.ToString().ToLowerInvariant());
+
             var query = AddQueryString(
                 ApiPath(database, $"document/{UrlEncode(collection)}"), parameter);
 
@@ -261,11 +274,12 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default)
+						bool? exclusive = null,
+						CancellationToken cancellationToken = default)
         {
             var res = await UpdateManyAsync<T, ArangoVoid>(database, collection,
                 new List<T> { doc }, waitForSync, keepNull, mergeObjects,
-                returnOld, returnNew, silent, ignoreRevs, cancellationToken).ConfigureAwait(false);
+                returnOld, returnNew, silent, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);
 
             return res.SingleOrDefault();
         }
@@ -279,11 +293,12 @@ namespace Core.Arango.Modules.Internal
             bool? returnNew = null,
             bool? silent = null,
             bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default)
+						bool? exclusive = null,
+						CancellationToken cancellationToken = default)
         {
             var res = await UpdateManyAsync<T, TR>(database, collection,
                 new List<T> { doc }, waitForSync, keepNull, mergeObjects,
-                returnOld, returnNew, silent, ignoreRevs, cancellationToken).ConfigureAwait(false);
+                returnOld, returnNew, silent, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);
 
             return res?.SingleOrDefault();
         }
@@ -294,7 +309,8 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default)
+						bool? exclusive = null,
+						CancellationToken cancellationToken = default)
         {
             var parameter = new Dictionary<string, string>();
 
@@ -303,9 +319,12 @@ namespace Core.Arango.Modules.Internal
 
             if (returnOld.HasValue)
                 parameter.Add("returnOld", returnOld.Value.ToString().ToLowerInvariant());
-
+            
             if (returnNew.HasValue)
                 parameter.Add("returnNew", returnNew.Value.ToString().ToLowerInvariant());
+
+            if (exclusive.HasValue)
+                parameter.Add("exclusive", returnNew.Value.ToString().ToLowerInvariant());
 
             if (ignoreRevs.HasValue)
                 parameter.Add("ignoreRevs", ignoreRevs.Value.ToString().ToLowerInvariant());
@@ -323,10 +342,11 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default)
+						bool? exclusive = null,
+						CancellationToken cancellationToken = default)
         {
             return await ReplaceManyAsync<T, ArangoVoid>(database, collection, docs,
-                waitForSync, returnOld, returnNew, ignoreRevs, cancellationToken).ConfigureAwait(false);
+                waitForSync, returnOld, returnNew, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ArangoUpdateResult<TR>> ReplaceAsync<T, TR>(ArangoHandle database, string collection,
@@ -335,10 +355,11 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default)
+						bool? exclusive = null,
+						CancellationToken cancellationToken = default)
         {
             var res = await ReplaceManyAsync<T, TR>(database, collection, new List<T> { doc },
-                waitForSync, returnOld, returnNew, ignoreRevs, cancellationToken).ConfigureAwait(false);
+                waitForSync, returnOld, returnNew, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);
 
             return res?.SingleOrDefault();
         }
@@ -349,10 +370,11 @@ namespace Core.Arango.Modules.Internal
             bool? returnOld = null,
             bool? returnNew = null,
             bool? ignoreRevs = null,
-            CancellationToken cancellationToken = default)
+						bool? exclusive = null,
+						CancellationToken cancellationToken = default)
         {
             var res = await ReplaceManyAsync<T, ArangoVoid>(database, collection, new List<T> { doc },
-                waitForSync, returnOld, returnNew, ignoreRevs, cancellationToken).ConfigureAwait(false);
+                waitForSync, returnOld, returnNew, ignoreRevs, exclusive, cancellationToken).ConfigureAwait(false);
 
             return res?.SingleOrDefault();
         }


### PR DESCRIPTION
Introduces the 'exclusive' parameter for document-based operations. This can enable more robust code when dealing with write-write errors, and in some cases, can be used to improve performance.

This is a breaking change, due to the additional optional argument. 