### PR TITLE
HTTP 2.0 Support

### DIFF
--- a/Core.Arango/Transport/ArangoHttpTransport.cs
+++ b/Core.Arango/Transport/ArangoHttpTransport.cs
@@ -147,6 +147,13 @@ namespace Core.Arango.Transport
         private void ApplyHeaders(string transaction, bool auth, HttpRequestMessage msg,
             IDictionary<string, string> headers)
         {
+#if NET8_0_OR_GREATER
+
+            msg.Version = _httpClient.DefaultRequestVersion;
+            msg.VersionPolicy = _httpClient.DefaultVersionPolicy;
+
+#endif
+
             msg.Headers.Add(HttpRequestHeader.KeepAlive.ToString(), "true");
 
             if (auth && !string.IsNullOrWhiteSpace(_auth))


### PR DESCRIPTION
This PR applies the HTTP Version to the `HttpRequestMessage`.
This is only available in .NET 8, since the `HttpClient` does not contain a `Version` before .NET 8.
You might extend configuration with a flag to tell whether to use `1.1` or `2.0` in this library, instead of using this PR.
Open for comments.

`HttpRequestMessage.Version`: "The default value is 1.1, unless you're targeting .NET Core 2.1 or 2.2. In that case, the default value is 2.0."
[https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httprequestmessage.version?view=netstandard-2.0#property-value](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httprequestmessage.version?view=netstandard-2.0#property-value)

ArangoDB supports HTTP 2.0:
[https://docs.arangodb.com/stable/develop/http-api/general-request-handling/](https://docs.arangodb.com/stable/develop/http-api/general-request-handling/)

Meanwhile, we use this solution:

```csharp
public class CustomHttpMessageHandler : DelegatingHandler
{
    public CustomHttpMessageHandler(HttpMessageHandler innerHandler)
        : base(innerHandler)
    {
    }

    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
    {
        request.Version = new Version(2, 0);
        request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;

        HttpResponseMessage response = await base.SendAsync(request, cancellationToken);

        return response;
    }
}
```

```csharp
var handler = new SocketsHttpHandler();

var customHttpHandler = new CustomHttpMessageHandler(handler);

HttpClient httpClient = new(customHttpHandler)
{
    DefaultRequestVersion = new Version(2, 0),
    DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact
};

ArangoConfiguration config = new()
{
    HttpClient = httpClient,
};

ArangoHttpTransport transport = new(config);

config.Transport = transport;

services.AddArango(arangoConfigSection.ConnectionString, config);
```
