### PR TITLE
Enable Exclusive Transactions.

### DIFF
--- a/Core.Arango.Tests/TransactionTest.cs
+++ b/Core.Arango.Tests/TransactionTest.cs
@@ -22,8 +22,9 @@ namespace Core.Arango.Tests
             {
                 Collections = new ArangoTransactionScope
                 {
-                    Write = new List<string> {"test"}
-                }
+                    Exclusive = ["test"]
+                },
+                AllowImplicit = false
             });
 
             await Arango.Document.CreateManyAsync(t1, "test", new List<Entity>
@@ -41,8 +42,9 @@ namespace Core.Arango.Tests
             {
                 Collections = new ArangoTransactionScope
                 {
-                    Write = new List<string> {"test"}
-                }
+                    Exclusive = ["test"]
+                },
+                AllowImplicit = false
             });
 
             await Arango.Document.CreateManyAsync(t2, "test", new List<Entity>

--- a/Core.Arango/Core.Arango.xml
+++ b/Core.Arango/Core.Arango.xml
@@ -5223,6 +5223,7 @@
                 An optional numeric value that can be used to set a timeout for waiting on collection locks.
                 If not specified, a default value will be used.
                 Setting lockTimeout to 0 will make ArangoDB not time out waiting for a lock.
+                This is only meaningful when using exclusive transaction locks.
             </summary>
         </member>
         <member name="P:Core.Arango.Protocol.ArangoTransaction.Params">
@@ -5248,6 +5249,11 @@
         <member name="P:Core.Arango.Protocol.ArangoTransactionScope.Write">
             <summary>
                 Collections to write to
+            </summary>
+        </member>
+        <member name="P:Core.Arango.Protocol.ArangoTransactionScope.Exclusive">
+            <summary>
+                Collections to write to with an exclusive lock
             </summary>
         </member>
         <member name="T:Core.Arango.Protocol.ArangoUpdateResult`1">

--- a/Core.Arango/Protocol/ArangoTransaction.cs
+++ b/Core.Arango/Protocol/ArangoTransaction.cs
@@ -55,6 +55,7 @@ namespace Core.Arango.Protocol
         ///     An optional numeric value that can be used to set a timeout for waiting on collection locks.
         ///     If not specified, a default value will be used.
         ///     Setting lockTimeout to 0 will make ArangoDB not time out waiting for a lock.
+        ///     This is only meaningful when using exclusive transaction locks.
         /// </summary>
         [JsonPropertyName("lockTimeout")]
         [JsonProperty(PropertyName = "lockTimeout", NullValueHandling = NullValueHandling.Ignore)]

--- a/Core.Arango/Protocol/ArangoTransactionScope.cs
+++ b/Core.Arango/Protocol/ArangoTransactionScope.cs
@@ -24,5 +24,14 @@ namespace Core.Arango.Protocol
         [JsonProperty(PropertyName = "write", NullValueHandling = NullValueHandling.Ignore)]
         [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<string> Write { get; set; }
+        
+
+        /// <summary>
+        ///     Collections to write to with an exclusive lock
+        /// </summary>
+        [JsonPropertyName("exclusive")]
+        [JsonProperty(PropertyName = "exclusive", NullValueHandling = NullValueHandling.Ignore)]
+        [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string> Exclusive { get; set; }
     }
 }


### PR DESCRIPTION
Without this, the Timeout value does nothing.
It also helps avoid those darned write-write conflicts.

Relevant Documentation:
https://docs.arangodb.com/devel/develop/http-api/transactions/stream-transactions/#begin-a-stream-transaction_body_collections
https://docs.arangodb.com/devel/develop/http-api/transactions/stream-transactions/#begin-a-stream-transaction_body_lockTimeout